### PR TITLE
Temporarily hardcoding Instagram followers

### DIFF
--- a/shared/components/services/numbers.tsx
+++ b/shared/components/services/numbers.tsx
@@ -6,21 +6,11 @@ import axios from 'axios'
 import { AiFillGithub, AiFillInstagram, AiFillYoutube } from 'react-icons/ai'
 
 const Stats = () => {
-  const [followers, setFollowers] = useState('')
+  const [followers, setFollowers] = useState('3540')
   const [repos, setRepos] = useState('')
   const [subscribers, setSubscribers] = useState('')
 
   useEffect(() => {
-    axios
-      .get('https://www.instagram.com/srmkzilla/?__a=1', {
-        headers: { 'content-type': 'application/json' },
-      })
-      .then((res) => {
-        setFollowers(res?.data?.graphql?.user?.edge_followed_by.count)
-      })
-      .catch((err) => {
-        setFollowers('2400')
-      })
     axios
       .get('https://api.github.com/users/srm-kzilla', {
         headers: { 'content-type': 'application/json' },


### PR DESCRIPTION
# Description

Hardcoded instagram follower count to `3540` on /services as a temporary "fix" to `/?__a=1` endpoint being unusable(?) 

Fixes https://github.com/srm-kzilla/srmkzilla-net/issues/58

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
