### PR TITLE
refactor: use `SANITY_PROJECT_ID` as server env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
 NEXT_PUBLIC_YOUTUBE_KEY = <string : Youtube Key>
-NEXT_PUBLIC_SANITY_PROJECT_ID = <string : Project ID>
+SANITY_PROJECT_ID = <string : Project ID>
 INSTA_KEY = <string : Instagram Client Access Token>
 NEXT_PUBLIC_BASE_URL = <string : API URL>

--- a/pages/projects/[slug].tsx
+++ b/pages/projects/[slug].tsx
@@ -4,7 +4,7 @@ import InstagramEmbed from 'react-instagram-embed'
 import Tilt from 'react-parallax-tilt'
 import Footer from '../../shared/components/footer'
 import * as BlockContent from '@sanity/block-content-to-react'
-import {getProjectDetails, getProjects, getProjectSlugs} from "@lib/sanity-api";
+import { getProjectDetails , getProjectSlugs } from "@lib/sanity-api";
 const Fade = require('react-reveal/Fade')
 
 type Props = {

--- a/pages/team/index.tsx
+++ b/pages/team/index.tsx
@@ -5,13 +5,6 @@ import NewCarousel from '@shared/components/team/carousel'
 import MemberCard from '@shared/components/team/membercard'
 import Head from 'next/head'
 
-import imageUrlBuilder from '@sanity/image-url'
-import sanityClient from '../../shared/client'
-
-function imageUrl(src) {
-  return imageUrlBuilder(sanityClient).image(src)
-}
-
 const Team = ({ teamMembers }) => {
   return (
     <>
@@ -63,7 +56,7 @@ const Team = ({ teamMembers }) => {
                       return (
                         <MemberCard
                           key={index}
-                          src={imageUrl(member?.picture?.asset?.url).url()}
+                          src={member?.picture?.asset?.url}
                           name={member?.name}
                           designation={member?.designation}
                           audioUrl={member?.description?.asset?.url}

--- a/shared/client.ts
+++ b/shared/client.ts
@@ -1,7 +1,7 @@
 import sanityClient from "@sanity/client";
 
 export default sanityClient({
-  projectId: `${process.env.NEXT_PUBLIC_SANITY_PROJECT_ID}`,
+  projectId: `${process.env.SANITY_PROJECT_ID}`,
   dataset: 'production',
   useCdn: true,
 })


### PR DESCRIPTION
# Description

This PR 
- removes the use of `imageUrlBuilder` and now sanity client is only on the server 
- rename: `NEXT_PUBLIC_SANITY_PROJECT_ID` -> `SANITY_PROJECT_ID`

###  builds without errors!
![image](https://github.com/srm-kzilla/srmkzilla-net/assets/64266012/a45e9ee8-7f15-4e5d-b304-72c3b757dd37)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
