### PR TITLE
Add dropdown menu for team in Navbar

### DIFF
--- a/shared/components/navbar.tsx
+++ b/shared/components/navbar.tsx
@@ -77,14 +77,36 @@ const Navbar = () => {
                   Our Services
                 </p>
               </Link>
-              <Link href="/team">
+              {/* <Link href="/team">
                 <p
                   onClick={() => setOpen(!open)}
                   className="md:my-2 mx-2 my-2 px-2 py-1 transition duration-500 ease-in-out hover:border-orange300 cursor-pointer border-b-2 border-transparent"
                 >
                   Team
                 </p>
-              </Link>
+              </Link> */}
+              <Dropdown
+                name="Team"
+                class="absolute md:ml-0 ml-14 md:my-12 md:mx-10 md:top-3 py-2 w-48 rounded-md shadow-md bg-black-200 cursor-pointer"
+                items={[
+                  // {
+                  //   label: 'Events',
+                  //   link: 'https://srmkzilla.net/events',
+                  //   newTab: true,
+                  // },
+                  {
+                    label: 'Current',
+                    link: '/team',
+                    newTab: false,
+                  },
+                  {
+                    label: '2022',
+                    link: '/team/2022',
+                    newTab: false,
+                  },
+                ]}
+                nameClass="md:my-2 mx-2 my-2 px-2 py-1 transition duration-500 ease-in-out relative z-10 hover:border-orange300 cursor-pointer border-b-2 border-transparent focus:outline-none"
+              />
               <Link href="/projects">
                 <p
                   onClick={() => setOpen(!open)}

--- a/shared/components/navbar.tsx
+++ b/shared/components/navbar.tsx
@@ -77,23 +77,10 @@ const Navbar = () => {
                   Our Services
                 </p>
               </Link>
-              {/* <Link href="/team">
-                <p
-                  onClick={() => setOpen(!open)}
-                  className="md:my-2 mx-2 my-2 px-2 py-1 transition duration-500 ease-in-out hover:border-orange300 cursor-pointer border-b-2 border-transparent"
-                >
-                  Team
-                </p>
-              </Link> */}
               <Dropdown
                 name="Team"
                 class="absolute md:ml-0 ml-14 md:my-12 md:mx-10 md:top-3 py-2 w-48 rounded-md shadow-md bg-black-200 cursor-pointer"
                 items={[
-                  // {
-                  //   label: 'Events',
-                  //   link: 'https://srmkzilla.net/events',
-                  //   newTab: true,
-                  // },
                   {
                     label: 'Current',
                     link: '/team',


### PR DESCRIPTION
# Description

Add a dropdown for teams in the navbar to show options to choose which years of team info to view

Desktop View:

![image](https://github.com/srm-kzilla/srmkzilla-net/assets/94288311/7bbda4e8-e479-4795-93ce-499bc358e929)

Mobile View:

![image](https://github.com/srm-kzilla/srmkzilla-net/assets/94288311/dd59e7b2-89a2-44a4-9687-714088a0b831)


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested using the inspect tab for responsiveness and links were tested by clicking manually


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules