### PR TITLE
feat: Adding `/events/register/success` page

### DIFF
--- a/pages/events/register/success.tsx
+++ b/pages/events/register/success.tsx
@@ -22,7 +22,7 @@ const Success = () => {
         <h1 className="text-center text-white text-4xl mt-16">Success</h1>
 
         <p className="text-center text-white text-3xl">
-            You have successfully registered for the event
+          You have successfully registered for the event
         </p>
       </div>
       <img

--- a/pages/events/register/success.tsx
+++ b/pages/events/register/success.tsx
@@ -1,0 +1,48 @@
+import React, { useEffect } from 'react'
+import { motion } from 'framer-motion'
+import Link from 'next/link'
+import Head from 'next/head'
+import Image from 'next/image'
+
+const Success = () => {
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      window.location.replace("/events");
+    }, 3000);
+    return () => clearTimeout(timeout);
+  })
+  return (
+    <div className="bg-gray500 h-screen w-screen overflow-hidden z-30 relative">
+      <Head>
+        <title>Success</title>
+        <meta name="description" content="Success page" />
+        <link rel="icon preload canonical" href="./images/kzillalogo.png" />
+      </Head>
+      <div className="z-30 relative">
+        <h1 className="text-center text-white text-4xl mt-16">Success</h1>
+
+        <p className="text-center text-white text-3xl">
+            You have successfully registered for the event
+        </p>
+      </div>
+      <img
+        src="./images/404bg.png"
+        className="z-20 w-full xl:h-auto h-96 object-fill absolute bottom-0 xl:-mb-20 mb-0 left-0"
+        alt="background"
+      />
+      <motion.img
+        initial={{ opacity: 1 }}
+        animate={{ opacity: 0.3 }}
+        transition={{ yoyo: Infinity, duration: 2 }}
+        src="./images/404stars.png"
+        className="absolute top-0 left-0 w-screen h-screen object-cover z-0"
+        alt="stars"
+      />
+      <div className="absolute z-10 xl:w-5/12 bg w-9/12 top-96 lg:mt-56 left-1/2 transform -translate-y-1/2 -translate-x-1/2">
+        <Image height={1000} width={1500} src="/images/err.png" alt="404" />
+      </div>
+    </div>
+  )
+}
+
+export default Success

--- a/pages/register.tsx
+++ b/pages/register.tsx
@@ -79,7 +79,7 @@ const Register = ({
         )
         reward()
         setTimeout(() => {
-          Router.push('/events')
+          Router.push('/events/register/success')
         }, 2000)
       } else if (registerUser.status === 502) {
         toast.warn(


### PR DESCRIPTION
# Description

Added a new page just to display a successful message to avoid confusion after the user registered for an event

Fixes # (issue)
#79 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Went to the URL `/events/register/success` and waited for 3 seconds for it to redirect automatically to the `/events` page

**Test Configuration**:

- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
      '+
