### PR TITLE
fix: reroute 'Know more' to events

### DIFF
--- a/shared/components/home/card.tsx
+++ b/shared/components/home/card.tsx
@@ -1,4 +1,5 @@
 import { motion } from 'framer-motion'
+import Link from 'next/dist/client/link'
 
 const HomeCard = (props: {
   name: String
@@ -23,11 +24,11 @@ const HomeCard = (props: {
       </h1>
       <p className="text-white font-light px-3 mt-3 text-xs">{props.desc}</p>
       <div className="text-center mt-10 mb-5">
-        <a href={`${props.link}`} target="_blank" rel="noopener noreferrer">
+        <Link href={`/events`}>
           <button className="bg-black border rounded-full text-white text-xs px-5 py-1 border-white focus:outline-none">
             Know More
           </button>
-        </a>
+        </Link>
       </div>
     </motion.div>
   )

--- a/shared/components/home/card.tsx
+++ b/shared/components/home/card.tsx
@@ -1,5 +1,5 @@
 import { motion } from 'framer-motion'
-import Link from 'next/dist/client/link'
+import Link from 'next/link'
 
 const HomeCard = (props: {
   name: String
@@ -25,9 +25,11 @@ const HomeCard = (props: {
       <p className="text-white font-light px-3 mt-3 text-xs">{props.desc}</p>
       <div className="text-center mt-10 mb-5">
         <Link href={`/events`}>
-          <button className="bg-black border rounded-full text-white text-xs px-5 py-1 border-white focus:outline-none">
-            Know More
-          </button>
+          <a>
+            <button className="bg-black border rounded-full text-white text-xs px-5 py-1 border-white focus:outline-none">
+              Know More
+            </button>
+          </a>
         </Link>
       </div>
     </motion.div>


### PR DESCRIPTION
# Description

- Rerouted 'Know-more' on the home page to the events page
- The "Know more" button in the home page
![image](https://github.com/srm-kzilla/srmkzilla-net/assets/99209457/613b041e-3b97-4dc9-a5ec-4ddb298310b0)

- Redirected to Events page
![image](https://github.com/srm-kzilla/srmkzilla-net/assets/99209457/077c7a38-c3c1-4a95-bf43-59a77b9dfbd8)

- Fixes #85 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
