### PR TITLE
fix: socials in speaker card

### DIFF
--- a/pages/events/[slug].tsx
+++ b/pages/events/[slug].tsx
@@ -77,7 +77,7 @@ export async function getStaticProps(context: { params: { slug: string } }) {
   let eventDetails: EventType
   const pageSlug = context.params.slug
   try {
-    eventDetails = await getEvent(pageSlug)
+    eventDetails = await getEvent(pageSlug);
   } catch (err) {
     return {
       notFound: true,

--- a/shared/components/events/speaker-card.tsx
+++ b/shared/components/events/speaker-card.tsx
@@ -58,18 +58,18 @@ const SpeakerCard = ({ speaker }: { speaker: SpeakerType }) => {
         </p>
         <div className="h-10 md:h-32"></div>
         <div className="grid md:absolute bottom-6 gap-3 grid-cols-2 md:grid-cols-3 md:gap-4 mx-auto justify-center md:justify-start">
-          <div>
-            {linkedIn && <LinkElement link={linkedIn} {...social.linkedIn} />}
-          </div>
-          {/* <div>
-            {githubLink && <LinkElement link={githubLink} {...social.github} />}
-          </div> */}
-           <div>
-            {instagramLink && <LinkElement link={instagramLink} {...social.instagram} />}
-          </div>
-          <div>
-            {email && <LinkElement link={`mailto:${email}`} {...social.mail} />}
-          </div>
+          {linkedIn && <div>
+            {<LinkElement link={linkedIn} {...social.linkedIn} />}
+          </div>}
+          {githubLink && <div>
+            <LinkElement link={githubLink} {...social.github} />
+          </div>}
+          {instagramLink && <div>
+            {<LinkElement link={instagramLink} {...social.instagram} />}
+          </div>}
+          {email && <div>
+            {<LinkElement link={`mailto:${email}`} {...social.mail} />}
+          </div>}
         </div>
       </div>
     </div>


### PR DESCRIPTION
# Description

Speaker card's social link gave spaces before when a link or info was not provided
![WhatsApp Image 2023-08-10 at 10 38 29](https://github.com/srm-kzilla/srmkzilla-net/assets/69302420/71f80382-0dc2-4e4b-8d17-56f56f6d3c04)


Fixes #91 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Checked in Browser
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
      '+
